### PR TITLE
27 checkbudgetlimit

### DIFF
--- a/src/main/java/dbaccess/DBAccess.java
+++ b/src/main/java/dbaccess/DBAccess.java
@@ -371,13 +371,6 @@ public class DBAccess {
 
 	// Warnings-Methoden
 
-	// Methode um die Kategorien zurückzugeben, bei denen das BudgetLimit überschritten wurden
-    public List<Category> checkBudgetExceeded() {
-	    TypedQuery<Category> query = entityManager.createNamedQuery("checkBudgetExceeded", Category.class);
-
-	    return query.getResultList();
-	}
-
 	// CSV-Methoden
 
 	// Methode zum Exportieren aller Kategorien in eine CSV-Datei

--- a/src/main/java/model/Category.java
+++ b/src/main/java/model/Category.java
@@ -17,9 +17,6 @@ import jakarta.persistence.Table;
 @Table(name = "categories")
 @NamedQueries({
 @NamedQuery(name="getAllCategories", query="SELECT category FROM Category category"),
-@NamedQuery(name="checkBudgetExceeded", query = "SELECT c FROM Category c WHERE c.categoryLimit < " +
-                                                "(SELECT SUM(t.transactionAmount) FROM Transaction t WHERE " + "t.category.categoryId = c.categoryId AND " +
-                                                                                                               "t.transactionType = 'spending' )"),
 @NamedQuery(name="checkBudgetLimit", query = "SELECT c FROM Category c WHERE :percent * c.categoryLimit < " +
                                                 "(SELECT COALESCE(SUM(t.transactionAmount), 0) FROM Transaction t WHERE " + "t.category.categoryId = c.categoryId AND " +
                                                                                                                "t.transactionType = 'spending' )")


### PR DESCRIPTION
Ersetze checkBudgetExceeded und checkBudget90Percent mit einer mehr anpassbaren Methode checkBudgetLimit.

Der Benutzer kann in der checkBudgetLimit Methode selber den Prozentsatz festlegen, um das ein Budget überschritten werden muss.

Zum Beispiel, wenn man als Parameter 0.9 setzt, wann werden alle Kategorien ausgegeben, die das Budget um 90% überschreiten. Wenn man 1 setzt, dann 100%