### PR TITLE
193-autowired-annotation-entfernen

### DIFF
--- a/src/main/java/api/CategoryController.java
+++ b/src/main/java/api/CategoryController.java
@@ -2,7 +2,6 @@ package api;
 
 import java.util.Collection;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +27,6 @@ public class CategoryController {
     private final DBAccessCategory dbAccessCategory;
     private final ControllerTools controllerTools;
 
-    @Autowired
     public CategoryController(DBAccessCategory dbAccessCategory, ControllerTools controllerTools) {
         this.dbAccessCategory = dbAccessCategory;
         this.controllerTools = controllerTools;

--- a/src/main/java/api/DashboardController.java
+++ b/src/main/java/api/DashboardController.java
@@ -2,7 +2,6 @@ package api;
 
 import java.util.Collection;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,7 +21,6 @@ public class DashboardController {
     private final DBAccessTransaction dbAccessTransaction;
     private final ControllerTools controllerTools;
 
-    @Autowired
     public DashboardController(DBAccessTransaction dbAccessTransaction, ControllerTools controllerTools) {
         this.dbAccessTransaction = dbAccessTransaction;
         this.controllerTools = controllerTools;

--- a/src/main/java/api/WarningController.java
+++ b/src/main/java/api/WarningController.java
@@ -2,7 +2,6 @@ package api;
 
 import java.util.Collection;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -19,7 +18,6 @@ public class WarningController {
     private final DBAccessWarning dbAccessWarning;
     private final ControllerTools controllerTools;
 
-    @Autowired
     public WarningController(DBAccessWarning dbAccessWarning, ControllerTools controllerTools) {
         this.dbAccessWarning = dbAccessWarning;
         this.controllerTools = controllerTools;

--- a/src/main/java/dbaccess/DBAccessCSV.java
+++ b/src/main/java/dbaccess/DBAccessCSV.java
@@ -2,7 +2,6 @@ package dbaccess;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.EntityManager;
@@ -15,7 +14,6 @@ public class DBAccessCSV {
     @PersistenceContext
 	private final EntityManager entityManager;
 
-	@Autowired
 	public DBAccessCSV(EntityManager entityManager) {
 
 		this.entityManager = entityManager;

--- a/src/main/java/dbaccess/DBAccessCategory.java
+++ b/src/main/java/dbaccess/DBAccessCategory.java
@@ -2,7 +2,6 @@ package dbaccess;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.EntityManager;
@@ -15,7 +14,6 @@ public class DBAccessCategory {
     @PersistenceContext
 	private final EntityManager entityManager;
 
-	@Autowired
 	public DBAccessCategory(EntityManager entityManager) {
 
 		this.entityManager = entityManager;

--- a/src/main/java/dbaccess/DBAccessTransaction.java
+++ b/src/main/java/dbaccess/DBAccessTransaction.java
@@ -2,7 +2,6 @@ package dbaccess;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.EntityManager;
@@ -17,7 +16,6 @@ public class DBAccessTransaction {
     @PersistenceContext
 	private final EntityManager entityManager;
 
-	@Autowired
 	public DBAccessTransaction(EntityManager entityManager) {
 
 		this.entityManager = entityManager;

--- a/src/main/java/dbaccess/DBAccessUser.java
+++ b/src/main/java/dbaccess/DBAccessUser.java
@@ -3,7 +3,6 @@ package dbaccess;
 import java.util.Arrays;
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.EntityManager;
@@ -18,7 +17,6 @@ public class DBAccessUser {
 	@PersistenceContext
 	private final EntityManager entityManager;
 
-	@Autowired
 	public DBAccessUser(EntityManager entityManager) {
 
 		this.entityManager = entityManager;

--- a/src/main/java/dbaccess/DBAccessWarning.java
+++ b/src/main/java/dbaccess/DBAccessWarning.java
@@ -2,7 +2,6 @@ package dbaccess;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import jakarta.persistence.EntityManager;
@@ -15,7 +14,6 @@ public class DBAccessWarning {
 	@PersistenceContext
 	private final EntityManager entityManager;
 
-	@Autowired
 	public DBAccessWarning(EntityManager entityManager) {
 
 		this.entityManager = entityManager;


### PR DESCRIPTION
Habe überall @Autowired entfernt, weil es bei einem Konstruktor unnötig ist, weil es Spring automatisch macht. 